### PR TITLE
Apply fix for where countdown timer reaches target with 0.9 seconds remaining on clock

### DIFF
--- a/src/easytimer.js
+++ b/src/easytimer.js
@@ -292,7 +292,9 @@ var Timer = (
             function isCountdownTimerTargetAchieved() {
                 return counters.hours < target[HOURS_POSITION]
                     || (counters.hours === target[HOURS_POSITION] && (counters.minutes < target[MINUTES_POSITION]
-                        || (counters.minutes === target[MINUTES_POSITION]) && counters.seconds <= target[SECONDS_POSITION]));
+                    || (counters.minutes === target[MINUTES_POSITION] && (counters.seconds < target[SECONDS_POSITION]
+                    || (counters.seconds === target[SECONDS_POSITION] && (counters.secondTenths < target[SECOND_TENTHS_POSITION]
+                    || counters.secondTenths === target[SECOND_TENTHS_POSITION] ))))));
             }
 
             function isTargetAchieved() {


### PR DESCRIPTION
We discovered this bug as we are using the countdown timer in an app and we have 2 clocks, a game clock (starts at 8mins) and shot clock (starts at 40secs).  When we start the clocks at the same time the shot clock ends however the game clock was still displaying 7mins, 20secs, 9tenths. This highlighted that the countdown timer with second tenths precision is actually reaching it's target when seconds are 0 and not when seconds and secondTenths are 0 