### PR TITLE
Require should exist to be called

### DIFF
--- a/src/easytimer.js
+++ b/src/easytimer.js
@@ -69,7 +69,7 @@ var Timer = (
                 hours: HOURS_PER_DAY
             },
 
-            events = module && module.exports? require('events') : undefined,
+            events = module && module.exports && typeof require === 'function' ? require('events') : undefined,
 
             prototype;
 


### PR DESCRIPTION
This fixes a `require is not defined` problem when running tests though [Karma](https://karma-runner.github.io), where node isn't used but `module` and `module.exports` can be defined by other dependencies. Checking if require is a function is often "more reliable".